### PR TITLE
User new Google endpoints for OAuth

### DIFF
--- a/social/backends/google.py
+++ b/social/backends/google.py
@@ -12,7 +12,10 @@ class BaseGoogleAuth(object):
     def get_user_id(self, details, response):
         """Use google email as unique id"""
         if self.setting('USE_UNIQUE_USER_ID', False):
-            return response['id']
+            if 'sub' in response:
+                return response['sub']
+            else:
+                return response['id']
         else:
             return details['email']
 
@@ -20,24 +23,14 @@ class BaseGoogleAuth(object):
         """Return user details from Google API account"""
         if 'email' in response:
             email = response['email']
-        elif 'emails' in response:
-            email = response['emails'][0]['value']
         else:
             email = ''
 
-        if isinstance(response.get('name'), dict):
-            names = response.get('name') or {}
-            name, given_name, family_name = (
-                response.get('displayName', ''),
-                names.get('givenName', ''),
-                names.get('familyName', '')
-            )
-        else:
-            name, given_name, family_name = (
-                response.get('name', ''),
-                response.get('given_name', ''),
-                response.get('family_name', '')
-            )
+        name, given_name, family_name = (
+            response.get('name', ''),
+            response.get('given_name', ''),
+            response.get('family_name', ''),
+        )
 
         fullname, first_name, last_name = self.get_user_names(
             name, given_name, family_name
@@ -64,14 +57,13 @@ class BaseGoogleOAuth2API(BaseGoogleAuth):
 
     def user_data(self, access_token, *args, **kwargs):
         """Return user data from Google API"""
-        if self.setting('USE_DEPRECATED_API', False):
-            url = 'https://www.googleapis.com/oauth2/v1/userinfo'
-        else:
-            url = 'https://www.googleapis.com/plus/v1/people/me'
-        return self.get_json(url, params={
-            'access_token': access_token,
-            'alt': 'json'
-        })
+        return self.get_json(
+            'https://www.googleapis.com/oauth2/v3/userinfo',
+            params={
+                'access_token': access_token,
+                'alt': 'json'
+            }
+        )
 
     def revoke_token_params(self, token, uid):
         return {'token': token}
@@ -91,10 +83,6 @@ class GoogleOAuth2(BaseGoogleOAuth2API, BaseOAuth2):
     REVOKE_TOKEN_METHOD = 'GET'
     # The order of the default scope is important
     DEFAULT_SCOPE = ['openid', 'email', 'profile']
-    DEPRECATED_DEFAULT_SCOPE = [
-        'https://www.googleapis.com/auth/userinfo.email',
-        'https://www.googleapis.com/auth/userinfo.profile'
-    ]
     EXTRA_DATA = [
         ('refresh_token', 'refresh_token', True),
         ('expires_in', 'expires'),
@@ -114,11 +102,6 @@ class GooglePlusAuth(BaseGoogleOAuth2API, BaseOAuth2):
     DEFAULT_SCOPE = [
         'https://www.googleapis.com/auth/plus.login',
         'https://www.googleapis.com/auth/plus.me',
-    ]
-    DEPRECATED_DEFAULT_SCOPE = [
-        'https://www.googleapis.com/auth/plus.login',
-        'https://www.googleapis.com/auth/userinfo.email',
-        'https://www.googleapis.com/auth/userinfo.profile'
     ]
     EXTRA_DATA = [
         ('id', 'user_id'),
@@ -140,7 +123,7 @@ class GooglePlusAuth(BaseGoogleOAuth2API, BaseOAuth2):
         if 'access_token' in self.data:  # Client-side workflow
             token = self.data.get('access_token')
             response = self.get_json(
-                'https://www.googleapis.com/oauth2/v1/tokeninfo',
+                'https://www.googleapis.com/oauth2/v3/tokeninfo',
                 params={'access_token': token}
             )
             self.process_error(response)


### PR DESCRIPTION
BIG NOTE: This PR is on top of the tag v0.2.21 and NOT the HEAD

* The old google+ endpoints are being deprecated in the 7th of March 2018.
This commit replays some changes applied in https://github.com/python-social-auth/social-core
allowing the use of the new versions of the google API.

* This fix is a temporary one as during the Django v1.11 upgrade we are going to migrate to the new package.

Relevant commits:
https://github.com/python-social-auth/social-core/commit/76687144d1b6fe4901c9c3a4a10fab2040ecfd8f
https://github.com/python-social-auth/social-core/commit/54e245c58366d513d3b02e0b5ea18146be04ea16