### PR TITLE
[DNM] Compat for dj111

### DIFF
--- a/social/backends/base.py
+++ b/social/backends/base.py
@@ -57,7 +57,7 @@ class BaseAuth(object):
         Call this method on any override of auth_complete."""
         pass
 
-    def authenticate(self, *args, **kwargs):
+    def authenticate(self, request, *args, **kwargs):
         """Authenticate user using social credentials
 
         Authentication is made if this is the correct backend, backend


### PR DESCRIPTION
Due to the the broad acceptance of args and kwargs of the
`social.backends.base.BaseAuth.authenticate` interface django 1.11 mistakes
it for a compatible module passing the request object as an argument.
This leads to erratic behaviour and failure on behalf of the user (during sign in).

* Created a django 1.11 compatibility branch expecting the request object as first argument and disregarging it for the rest of the auth flow